### PR TITLE
jenkins upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 This repository contains a Jenkins-as-Code approach. 
-Everything is tested and running with Jenkins `2.164.3` on minikube `v1.0.0`. 
+Everything is tested and running with Jenkins `2.190.1` on minikube `v1.0.0` (the .gif you above was done with an older version). 
 The setup is based on docker, helm and git so it can be easily applied in different infrastructures.
 Plugins and minimum setup are pre-baked inside a docker image. 
 A configuration and seeding pipeline provisions Jenkins with configuration code from a central git repository. 

--- a/resources/config/configuration-as-code-plugin/jenkins.yaml
+++ b/resources/config/configuration-as-code-plugin/jenkins.yaml
@@ -75,8 +75,6 @@ jenkins:
 security:
   globalJobDslSecurityConfiguration:
     useScriptSecurity: false
-  remotingCLI:
-    enabled: false
   sSHD:
     port: 6666
 

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM jenkins/jenkins:2.164.3
+FROM jenkins/jenkins:2.190.1
 
 ENV ARCH=linux_amd64 \
-    VAULT_VERSION=1.0.3 \
-    TERRAFORM_VERSION=0.11.11 
+    VAULT_VERSION=1.2.3 \
+    TERRAFORM_VERSION=0.12.8 
 
 # Disable install wizard
 ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false -Dorg.jenkinsci.main.modules.sshd.SSHD.hostName=127.0.0.1"

--- a/resources/docker/plugins.txt
+++ b/resources/docker/plugins.txt
@@ -35,6 +35,7 @@ git
 github-api
 github-branch-source
 handlebars
+hashicorp-vault-plugin
 icon-shim
 jackson2-api
 javadoc
@@ -62,6 +63,7 @@ pipeline-rest-api
 pipeline-stage-step
 pipeline-stage-tags-metadata
 pipeline-stage-view
+pipeline-utility-steps
 plain-credentials
 resource-disposer
 role-strategy

--- a/resources/helm/templates/statefulsets.yaml
+++ b/resources/helm/templates/statefulsets.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: jenkins
-        image: quay.io/devtail/jenkins-as-code:fishi0x01_jenkins-upgrade
+        image: quay.io/devtail/jenkins-as-code:master
         imagePullPolicy: Always
         env:
         - name: DEPLOY_TS

--- a/resources/helm/templates/statefulsets.yaml
+++ b/resources/helm/templates/statefulsets.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: jenkins
-        image: quay.io/devtail/jenkins-as-code:master
+        image: quay.io/devtail/jenkins-as-code:fishi0x01_jenkins-upgrade
         imagePullPolicy: Always
         env:
         - name: DEPLOY_TS


### PR DESCRIPTION
- Upgrade Jenkins to latest LTS `2.190.1`
- Upgrade Vault and Terraform clients